### PR TITLE
Increase version limit on 'base' for GHC 7.10 compatibility

### DIFF
--- a/hashable-time.cabal
+++ b/hashable-time.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules:  Data.Hashable.Time
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.7 && <4.8, hashable, time
+  build-depends:       base >=4.7 && <4.9, hashable, time
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options: -Wall -Werror


### PR DESCRIPTION
This commit just changes the upper bound on `base` to 4.9 from 4.8.  I was able to compile fine with 7.10.1 on Debian.
