### PR TITLE
Use time-compat, add instances for DayOfWeek, Month etc

### DIFF
--- a/hashable-time.cabal
+++ b/hashable-time.cabal
@@ -1,5 +1,5 @@
 name:                hashable-time
-version:             0.2.0.2
+version:             0.2.1
 synopsis:            Hashable instances for Data.Time
 description:
   Hashable instances for types in Data.Time
@@ -23,11 +23,13 @@ library
   default-language: Haskell2010
   ghc-options:      -Wall
   other-extensions: CPP
-  build-depends:    base >=4.7 && <4.15, hashable >=1.2.3.3 && <1.4
+  build-depends:    base >=4.7 && <4.16, hashable >=1.2.4 && <1.4, time-compat >=1.9.4 && <1.10
+
   if flag(old-locale)
     build-depends:  time >=1.4 && <1.5, old-locale >=1.0 && <1.1
   else
-    build-depends:  time >=1.5
+    build-depends:  time >=1.5 && <1.12
+
 
 source-repository head
   type:     git

--- a/src/Data/Hashable/Time.hs
+++ b/src/Data/Hashable/Time.hs
@@ -7,21 +7,18 @@
 -- Maintainer  : Alexey Karakulov <ankarakulov@gmail.com>
 module Data.Hashable.Time (Hashable(..)) where
 
-import Data.Fixed
 import Data.Hashable (Hashable(..))
-import Data.Time
+import Data.Time.Compat (UniversalTime (..), DiffTime, UTCTime (..),
+                         NominalDiffTime, Day (..), DayOfWeek (..), TimeZone (..),
+                         TimeOfDay (..), LocalTime (..), ZonedTime (..))
+import Data.Time.Calendar.Month.Compat (Month (..))
+import Data.Time.Calendar.Quarter.Compat (Quarter (..), QuarterOfYear (..))
 
-#if !MIN_VERSION_time(1,5,0)
-import System.Locale
-#endif
-
--- Dependencies
-
--- ! (>=1.2.4) ~ <1.2.4 ~ <= 1.2.3
-#if !MIN_VERSION_hashable(1,2,4)
--- https://github.com/tibbe/hashable/pull/101
-instance Hashable (Fixed a) where
-   hashWithSalt salt (MkFixed i) = hashWithSalt salt i
+-- time-compat doesn't redefine TimeLocale
+#ifdef MIN_VERSION_old_locale
+import System.Locale (TimeLocale (..))
+#else
+import Data.Time.Format.Compat (TimeLocale (..))
 #endif
 
 -- Data.Time.Clock
@@ -43,6 +40,18 @@ instance Hashable NominalDiffTime where
 
 instance Hashable Day where
   hashWithSalt salt (ModifiedJulianDay d) = hashWithSalt salt d
+
+instance Hashable Month where
+  hashWithSalt salt (MkMonth x) = hashWithSalt salt x
+
+instance Hashable Quarter where
+  hashWithSalt salt (MkQuarter x) = hashWithSalt salt x
+
+instance Hashable DayOfWeek where
+  hashWithSalt salt = hashWithSalt salt . fromEnum
+
+instance Hashable QuarterOfYear where
+  hashWithSalt salt = hashWithSalt salt . fromEnum
 
 -- Data.Time.LocalTime
 


### PR DESCRIPTION
time-compat provides the missing types and instances for time package,
such one don't need to upgrade it (which is sometimes difficult).

In longer run, I'd be happy to provide hashable instances
in time-compat itself. Yet I think first introducing dependency
to hashable-time would allow better migration story.

(FWIW time-compat is used by aeson etc.)